### PR TITLE
Add support for the turnstyle theme option

### DIFF
--- a/resources/views/turnstile.antlers.html
+++ b/resources/views/turnstile.antlers.html
@@ -1,1 +1,1 @@
-<div class="cf-turnstile" data-sitekey="{{ config:turnstile:sitekey }}"></div>
+<div class="cf-turnstile" data-sitekey="{{ config:turnstile:sitekey }}" data-theme="{{ theme ?? 'auto' }}"></div>

--- a/src/Fieldtypes/TurnstileFieldtype.php
+++ b/src/Fieldtypes/TurnstileFieldtype.php
@@ -12,7 +12,24 @@ class TurnstileFieldtype extends Fieldtype
   protected $icon = 'lock';
 
   public function view()
-    {
-        return 'statamic-turnstile::turnstile';
-    }
+  {
+    return 'statamic-turnstile::turnstile';
+  }
+
+  protected function configFieldItems(): array
+  {
+    return [
+      'theme' => [
+        'display'      => 'Theme',
+        'instructions' => 'Select Turnstile theme to use',
+        'type'         => 'select',
+        'default'      => 'auto',
+        'options'      => [
+          'auto'  => __( 'Auto' ),
+          'light' => __( 'Light' ),
+          'dark'  => __( 'Dark' ),
+        ]
+      ]
+    ];
+  }
 }

--- a/src/Tags/TurnstileTag.php
+++ b/src/Tags/TurnstileTag.php
@@ -16,7 +16,9 @@ class TurnstileTag extends Tags
   public function field()
   {
     $sitekey = config('turnstile.sitekey') ?? '';
-    return "<div class=\"cf-turnstile\" data-sitekey=\"".$sitekey."\"></div>";
+    $theme = $this->params->get('theme', 'auto');
+
+    return "<div class=\"cf-turnstile\" data-sitekey=\"".$sitekey."\" data-theme=\"".$theme."\"></div>";
   }
 
   /**


### PR DESCRIPTION
This adds support for the turnstile theme option! ([turnstile options docs](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#configurations))

It can be set in the GUI when creating the field as seen in the screenshot below. It can also be set when using the tag like `{{ turnstile:field theme="dark" }}` or `{{ turnstile:field theme="light" }}`.

![Screenshot 2024-10-15](https://github.com/user-attachments/assets/ecbb0a64-5462-4ba8-88dc-a611c469d334)
