### PR TITLE
Protect registration route using turnstile

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ This addon lets you secure your Statamic forms with Cloudflare Turnstile, an alt
 
 Simply add the script to your site via our custom tag and then add a Turnstile field to any form you want to protect. Everything else is done for you.
 
+You can also protect user registration forms by setting the `TURNSTILE_PROTECT_REGISTRATION` environment variable to `true`.
+If you're using this feature make sure to add `{{ turnstile:field }}` into the registration form page.
+
 ## How to Install
 
 Before setting up this addon you need to register with Cloudflare Turnstile and add your site. You will receive two keys that need to be added to your project's .env file.

--- a/config/turnstile.php
+++ b/config/turnstile.php
@@ -3,4 +3,6 @@
 return [
   'sitekey' => env('TURNSTILE_SITE_KEY', ''),
   'secretkey' => env('TURNSTILE_SECRET_KEY', ''),
+
+  'protect_registration' => env('TURNSTILE_PROTECT_REGISTRATION', false),
 ];

--- a/src/Listeners/TurnstileListener.php
+++ b/src/Listeners/TurnstileListener.php
@@ -22,7 +22,7 @@ class TurnstileListener
   /**
    * Handle the event.
    *
-   * @param  \App\Events\FormSubmitted  $event
+   * @param  \Statamic\Events\FormSubmitted  $event
    * @return void
    */
   public function handle(FormSubmitted $event)

--- a/src/Listeners/TurnstileListener.php
+++ b/src/Listeners/TurnstileListener.php
@@ -5,6 +5,7 @@ namespace Stoffelio\StatamicTurnstile\Listeners;
 use Statamic\Events\FormSubmitted;
 use Illuminate\Validation\ValidationException;
 use Statamic\Fields\Blueprint;
+use Stoffelio\StatamicTurnstile\Services\TurnstileService;
 
 class TurnstileListener
 {
@@ -27,7 +28,7 @@ class TurnstileListener
   public function handle(FormSubmitted $event)
   {
     if ($this->shouldVerify($event->submission->form()->blueprint())) {
-      if (!$this->verify(request()->input('cf-turnstile-response') ?? '')) {
+      if (!TurnstileService::verify(request()->input('cf-turnstile-response') ?? '')) {
         throw ValidationException::withMessages([__('statamic-turnstile::validation.turnstile')]);
       }
     }
@@ -41,29 +42,5 @@ class TurnstileListener
       }
     }
     return false;
-  }
-
-  // verifies the provided token with cloudflare's api
-  private function verify($token)
-  {
-    $url = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
-    $args = [
-      'secret' => config('turnstile.secretkey') ?? '',
-      'response' => $token
-    ];
-    
-    $ch = curl_init($url);
-    curl_setopt($ch, CURLOPT_POST, 1);
-    curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($args));
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-    $output = curl_exec($ch);
-    curl_close($ch);
-
-    $result = json_decode($output);
-    
-    if (! $result || ! $result->success) {
-        return false;
-    }
-    return true;
   }
 }

--- a/src/Listeners/TurnstileRegistrationListener.php
+++ b/src/Listeners/TurnstileRegistrationListener.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Stoffelio\StatamicTurnstile\Listeners;
+
+use Statamic\Events\UserRegistering;
+use Illuminate\Validation\ValidationException;
+use Stoffelio\StatamicTurnstile\Services\TurnstileService;
+
+class TurnstileRegistrationListener
+{
+
+  /**
+   * Create the event listener.
+   *
+   * @return void
+   */
+  public function __construct()
+  {
+    //
+  }
+
+  /**
+   * Handle the event.
+   *
+   * @param  \Statamic\Events\UserRegistering  $event
+   * @return void
+   */
+  public function handle(UserRegistering $event)
+  {
+    if (config('turnstile.protect_registration')) {
+      if (!TurnstileService::verify(request()->input('cf-turnstile-response') ?? '')) {
+        throw ValidationException::withMessages([__('statamic-turnstile::validation.turnstile')]);
+      }
+    }
+  }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -4,7 +4,9 @@ namespace Stoffelio\StatamicTurnstile;
 
 use Statamic\Providers\AddonServiceProvider;
 use Stoffelio\StatamicTurnstile\Listeners\TurnstileListener;
+use Stoffelio\StatamicTurnstile\Listeners\TurnstileRegistrationListener;
 use Statamic\Events\FormSubmitted;
+use Statamic\Events\UserRegistering;
 use Stoffelio\StatamicTurnstile\Tags\TurnstileTag;
 use Stoffelio\StatamicTurnstile\Fieldtypes\TurnstileFieldtype;
 
@@ -12,6 +14,7 @@ class ServiceProvider extends AddonServiceProvider
 {
     protected $listen = [
         FormSubmitted::class => [TurnstileListener::class],
+        UserRegistering::class => [TurnstileRegistrationListener::class],
     ];
 
     protected $tags = [

--- a/src/Services/TurnstileService.php
+++ b/src/Services/TurnstileService.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Stoffelio\StatamicTurnstile\Services;
+
+class TurnstileService
+{
+
+  // verifies the provided token with cloudflare's api
+  public static function verify($token)
+  {
+    $url = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
+    $args = [
+      'secret' => config('turnstile.secretkey') ?? '',
+      'response' => $token
+    ];
+    
+    $ch = curl_init($url);
+    curl_setopt($ch, CURLOPT_POST, 1);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($args));
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+    $output = curl_exec($ch);
+    curl_close($ch);
+
+    $result = json_decode($output);
+    
+    if (! $result || ! $result->success) {
+        return false;
+    }
+    return true;
+  }
+}


### PR DESCRIPTION
This PR adds a new listener on Statamic's UserRegistering event that is only enabled when the env variable TURNSTILE_PROTECT_REGISTRATION is set to true.

To not duplicate code I moved the verify function to a service so it can be reused

Updated README.md to reflect the new feature

This implements and closes #8 